### PR TITLE
Add CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This application is a simple checker/generator for environment files. It checks,
 In case you don't have .env file created or if it differs from schema file, it allows you to create the file through terminal prompt.
 
 ## 📐 Installation
+For global use
+```bash
+npm i --global dotenv-checker
+```
+For use in a project
 ```bash
 npm i --save-dev dotenv-checker
 ```
@@ -21,7 +26,17 @@ npm i --save-dev dotenv-checker
 #### 🔵 When environment file doesn't have some needed variable indicated in schema file
 ![Update file example](assets/update-file.svg)
 
-## 🚀 Usage
+## 🚀 CLI Usage
+
+Once installed, simply run the command from your terminal. Optional parameters are --env and --schema
+```bash
+dotenv-checker
+```
+```bash
+dotenv-checker --env .env.local --schema .env.example
+```
+
+## 🚀 Package Usage
 
 As the library process are executed asynchronously it returns a `Promise<void>` when the process is done.
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv-checker",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,6 +54,11 @@
       "requires": {
         "@types/babel-types": "*"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -624,14 +629,43 @@
       }
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "co": {
@@ -763,8 +797,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1687,6 +1720,22 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        }
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -1765,6 +1814,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-installed-path": {
       "version": "2.1.1",
@@ -2659,6 +2713,14 @@
         }
       }
     },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -3144,6 +3206,27 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
+    "p-limit": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
@@ -3349,6 +3432,23 @@
         "uglify-js": "^2.6.1"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -3358,6 +3458,20 @@
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
             "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
           }
         }
       }
@@ -3498,6 +3612,16 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
     "resolve": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -3625,6 +3749,11 @@
       "requires": {
         "semver": "^5.0.3"
       }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -4328,6 +4457,11 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
     "widest-line": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
@@ -4372,6 +4506,68 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -4427,6 +4623,11 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -4434,22 +4635,66 @@
       "dev": true
     },
     "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^16.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint src/**/*",
     "lint:copy-paste": "jscpd ."
   },
+  "bin": {
+    "dotenv-checker": "./src/cli.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chempogonzalez/dotenv-checker.git"
@@ -39,7 +42,8 @@
   },
   "dependencies": {
     "app-root-path": "^3.0.0",
-    "inquirer": "^7.0.4"
+    "inquirer": "^7.0.4",
+    "yargs": "^15.1.0"
   },
   "jscpd": {
     "mode": "mild",

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,11 +22,11 @@ const { checkEnvFile } = require('.');
 
 const workingDir = process.cwd();
 let schemaFile = argv.schema || '.env.schema';
-if (path.isAbsolute(schemaFile)) schemaFile = `${workingDir}/${schemaFile}`;
-let envFile = argv.env || '.env.schema';
-if (path.isAbsolute(envFile)) envFile = `${workingDir}/${envFile}`;
+if (!path.isAbsolute(schemaFile)) schemaFile = `${workingDir}/${schemaFile}`;
+let envFile = argv.env || '.env';
+if (!path.isAbsolute(envFile)) envFile = `${workingDir}/${envFile}`;
 const options = {
-  schemaFile: `${workingDir}/${argv.schema || '.env.schema'}`,
-  envFile: `${workingDir}/${argv.env || '.env'}`,
+  schemaFile,
+  envFile,
 };
 checkEnvFile(options).catch(console.error);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+const { argv } = require('yargs').options({
+  env: {
+    alias: 'e',
+    type: 'string',
+    usage: 'Usage: $0 --env .env.local',
+    describe: 'Name of the env file. Defaults to ".env.local"',
+  },
+  schema: {
+    alias: 's',
+    type: 'string',
+    usage: 'Usage: $0 --schema .env.schema',
+    describe: 'Name of the schema file. Defaults to ".env.schema"',
+  },
+}).strict(true)
+  .example('$0 --env .env.local', 'Run the command with a custom env file')
+  .example('$0 --schema .env.schema', 'Run the command with a custom schema file')
+  .example('$0 -e .env.dev -s .env.example', 'Run the command with a custom env and schema file')
+  .epilog('Made with ❤️');
+const { checkEnvFile } = require('.');
+
+const workingDir = process.cwd();
+const options = {
+  schemaFile: `${workingDir}/${argv.schema || '.env.schema'}`,
+  envFile: `${workingDir}/${argv.env || '.env'}`,
+};
+checkEnvFile(options).catch(console.error);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+const path = require('path');
 const { argv } = require('yargs').options({
   env: {
     alias: 'e',
@@ -20,6 +21,10 @@ const { argv } = require('yargs').options({
 const { checkEnvFile } = require('.');
 
 const workingDir = process.cwd();
+let schemaFile = argv.schema || '.env.schema';
+if (path.isAbsolute(schemaFile)) schemaFile = `${workingDir}/${schemaFile}`;
+let envFile = argv.env || '.env.schema';
+if (path.isAbsolute(envFile)) envFile = `${workingDir}/${envFile}`;
 const options = {
   schemaFile: `${workingDir}/${argv.schema || '.env.schema'}`,
   envFile: `${workingDir}/${argv.env || '.env'}`,

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const appRoot = require('app-root-path');
 const { prompt } = require('inquirer');
 const { getEnvContent } = require('./helpers');
@@ -19,7 +20,7 @@ const { path: rootPath } = appRoot;
  * @returns Promise<void>
  */
 const writeFile = (FILE, text) => new Promise((resolve, reject) => {
-  const fullPath = `${FILE.startsWith('/') ? '' : `${rootPath}/`}/${FILE}`;
+  const fullPath = `${path.isAbsolute(FILE) ? '' : `${rootPath}/`}/${FILE}`;
   const folderPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
   try {
     fs.mkdir(folderPath, { recursive: true }, (err) => {
@@ -105,7 +106,7 @@ const updateEnvFile = async (attributes, envContent, envFile) => {
  * @returns Promise<string>
  */
 const readFile = (FILE) => new Promise((resolve, reject) => {
-  const fullPath = `${FILE.startsWith('/') ? '' : `${rootPath}/`}/${FILE}`;
+  const fullPath = `${path.isAbsolute(FILE) ? '' : `${rootPath}/`}/${FILE}`;
   fs.readFile(fullPath, "utf8", (err, data) => {
     if (err) reject(err);
     else resolve(data);
@@ -123,7 +124,7 @@ const readFile = (FILE) => new Promise((resolve, reject) => {
  * @returns Promise<boolean>
  */
 const fileExists = (FILE) => new Promise((resolve, reject) => {
-  const fullPath = `${FILE.startsWith('/') ? '' : `${rootPath}/`}/${FILE}`;
+  const fullPath = `${path.isAbsolute(FILE) ? '' : `${rootPath}/`}/${FILE}`;
   fs.access(fullPath, fs.F_OK, (err) => {
     if (err) {
       reject(err);

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -19,7 +19,7 @@ const { path: rootPath } = appRoot;
  * @returns Promise<void>
  */
 const writeFile = (FILE, text) => new Promise((resolve, reject) => {
-  const fullPath = `${rootPath}/${FILE}`;
+  const fullPath = `${FILE.startsWith('/') ? '' : `${rootPath}/`}/${FILE}`;
   const folderPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
   try {
     fs.mkdir(folderPath, { recursive: true }, (err) => {
@@ -105,7 +105,7 @@ const updateEnvFile = async (attributes, envContent, envFile) => {
  * @returns Promise<string>
  */
 const readFile = (FILE) => new Promise((resolve, reject) => {
-  const fullPath = `${rootPath}/${FILE}`;
+  const fullPath = `${FILE.startsWith('/') ? '' : `${rootPath}/`}/${FILE}`;
   fs.readFile(fullPath, "utf8", (err, data) => {
     if (err) reject(err);
     else resolve(data);
@@ -120,10 +120,10 @@ const readFile = (FILE) => new Promise((resolve, reject) => {
  *
  * @param {string} FILE file name (path + name)
  *
- * @returns Promise<boolean
+ * @returns Promise<boolean>
  */
 const fileExists = (FILE) => new Promise((resolve, reject) => {
-  const fullPath = `${rootPath}/${FILE}`;
+  const fullPath = `${FILE.startsWith('/') ? '' : `${rootPath}/`}/${FILE}`;
   fs.access(fullPath, fs.F_OK, (err) => {
     if (err) {
       reject(err);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -30,7 +30,7 @@ const defaultOptions = {
 /**
  * @function checkEnvFile
  *
- * @description Checks if the environmet file already exists and compare it with the schema file.
+ * @description Checks if the environment file already exists and compare it with the schema file.
  *              1. In case .env not exists, prompt questions to the user
  *                in order to fill the needed env variables and create the .env file
  *


### PR DESCRIPTION
Package can now be installed as a global package and ran from the CLI. My testing showed that it worked fine with relative paths from inside a project
```bash
dotenv-checker -e .env -s ../../whyIsYourSchemaHere
```
That command would work, as it understands the relative path. It should also support absolute paths

I had to change the helpers that read and write files, as they would still prefix the path with the project directory even if supplied an absolute file path. Hopefully this doesn't affect anything else