### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ By default it auto updates the environment file if it differs from schema file. 
 
 ```bash
 # File to check that needs to be in sync with schema file
-dotenv-checker --skip-create-question=false
+dotenv-checker --skip-update-question=false
 ```
 
 <br>


### PR DESCRIPTION
Seems that example of `--skip-update-question` option actually contains `--skip-create-question` option.